### PR TITLE
Fix a bug around POST error handling

### DIFF
--- a/lib/hatena-blog-model.coffee
+++ b/lib/hatena-blog-model.coffee
@@ -53,12 +53,7 @@ module.exports = class HatenaBlogPost
     client.create {
       title: @entryTitle
       content: @entryBody
-
       categories: @categories
       draft: !@isPublic
     }, (err, res) ->
-      if err
-        callback err
-      else
-        callback res
-      return
+      callback res, err


### PR DESCRIPTION
Even though hatenaBlogPost#postEntry in HatenablogView#post failed, "console.log err" was not called
since the postEntry passes handler only err or res.
