### PR TITLE
Feature/update entry using context comment

### DIFF
--- a/lib/hatena-blog-model.coffee
+++ b/lib/hatena-blog-model.coffee
@@ -42,6 +42,9 @@ module.exports = class HatenaBlogPost
         markdown = "![](#{imageurl})"
         editor.setTextInBufferRange(range[0], markdown)
 
+  parseEntryId: (id) ->
+    return id._.match(/^tag:[^:]+:[^-]+-[^-]+-\d+-(\d+)$/)[1]
+
   postEntry: (callback) ->
     client = blog(
       type: 'wsse'
@@ -51,6 +54,28 @@ module.exports = class HatenaBlogPost
     )
 
     client.create {
+      title: @entryTitle
+      content: @entryBody
+      categories: @categories
+      draft: !@isPublic
+    }, (err, res) =>
+      if err
+        callback res, err
+      else
+        @entryId = @parseEntryId(res.entry.id)
+        callback res, err
+      return
+
+  updateEntry: (callback) ->
+    client = blog(
+      type: 'wsse'
+      username: @getHatenaId()
+      blogId:   @getBlogId()
+      apikey:   @getApiKey()
+    )
+
+    client.update {
+      id: @entryId
       title: @entryTitle
       content: @entryBody
       categories: @categories

--- a/lib/hatena-blog-model.coffee
+++ b/lib/hatena-blog-model.coffee
@@ -53,12 +53,7 @@ module.exports = class HatenaBlogPost
     client.create {
       title: @entryTitle
       content: @entryBody
-
       categories: @categories
       draft: !@isPublic
     }, (err, res) ->
-      if err
-        callback err
-      else
-        callback res
-      return
+      callback res, err

--- a/lib/hatena-blog.coffee
+++ b/lib/hatena-blog.coffee
@@ -8,10 +8,10 @@ module.exports =
     @hatenaBlogView = new HatenablogView(state.hatenaBlogViewState)
 
   deactivate: ->
-    @hatenablogView.destroy()
+    @hatenaBlogView.destroy()
 
   serialize: ->
-    hatenaBlogViewState: @hatenablogView.serialize()
+    hatenaBlogViewState: @hatenaBlogView.serialize()
 
   config:
     hatenaId:


### PR DESCRIPTION
コメントを利用して記事のなどができる機能を追加しました。
投稿の際に記事にコメントを挿入して entryId などの情報を管理します。
もしコメントを勝手に挿入してしまうこととh1要素をタイトルにして本文から削除してしまうことに違和感がなければ使ってください。

変更点:
- 記事先頭にコンテキストコメントを挿入して entryId, title, categories を管理するよう修正
- 記事の先頭が h1 要素だった場合、タイトルのデフォルト値として設定し、h1要素を削除してから投稿するよう修正
